### PR TITLE
layout: fix URL warnings from Hugo tool

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,7 +10,7 @@
         </button>
         <div class="collapse navbar-collapse justify-content-between" id="navbarNav">
             <ul class="navbar-nav">
-                {{ $url := .URL | relLangURL }}
+                {{ $url := .RelPermalink | relLangURL }}
                 {{ range .Site.Menus.main }}
                 <li class="nav-item {{ if eq $url (.URL | relLangURL) }}active{{end}}">
                     {{ if eq (hasPrefix .URL "mailto:") true }}


### PR DESCRIPTION
Hugo tool complains about Page.URL that is deprecated.

```
Building sites … WARN 2020/05/10 14:53:01 Page.URL is deprecated and will be removed in a future release. Use .Perma
link or .RelPermalink. If what you want is the front matter URL value, use .Params.url
```

A `.URL` remains in layouts/partials/header.html file. Now it uses a RelPermalink.

This commit fixes #2.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>